### PR TITLE
Create migration scripts for tree tags

### DIFF
--- a/migrations/20200623153908-CreateTag.js
+++ b/migrations/20200623153908-CreateTag.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  return db.createTable('tag', {
+    id: { type: 'int', primaryKey: true, autoIncrement: true},
+    tag_name: 'string',
+    active: {
+      type: 'boolean',
+      defaultValue: true,
+      notNull: true
+    },
+    public: {
+      type: 'boolean',
+      defaultValue: true,
+      notNull: true
+    },
+  });
+};
+
+exports.down = function(db) {
+  return db.dropTable('tag');
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/20200623154622-CreateTreeTag.js
+++ b/migrations/20200623154622-CreateTreeTag.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  return db.createTable('tree_tag', {
+    id: { type: 'int', primaryKey: true, autoIncrement: true},
+    tree_id: 'int',
+    tag_id: 'int',
+  });
+};
+
+exports.down = function(db) {
+  return db.dropTable('tree_tag');;
+};
+
+exports._meta = {
+  "version": 1
+};


### PR DESCRIPTION
Issue #26 

Migration scripts for initial implementation of tree tags.

1. Creates `tag` table to store arbitrary tag strings
1. Creates `tree_tag` table to link trees to tags by their respective IDs