### PR TITLE
Fix delete admin user

### DIFF
--- a/main/migrations/20201102215634-AddAdminUsernameConstraint.js
+++ b/main/migrations/20201102215634-AddAdminUsernameConstraint.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  return db.runSql('CREATE UNIQUE INDEX admin_user_un ON admin_user (user_name) where active = true');
+};
+
+exports.down = function(db) {
+  return db.runSql('DROP INDEX admin_user_un');
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/main/migrations/20201117211212-AddEnabledColumnToAdminUser.js
+++ b/main/migrations/20201117211212-AddEnabledColumnToAdminUser.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  return db.addColumn('admin_user', 'enabled', { type: 'boolean', defaultValue: true, notNull: true })
+};
+
+exports.down = function(db) {
+  return db.removeColumn('admin_user', 'enabled')
+};
+
+exports._meta = {
+  "version": 1
+};


### PR DESCRIPTION
Addresses the database elements of Greenstand/treetracker-admin#418
To be deployed in conjunction with Greenstand/treetracker-admin#457

- Make active usernames unique
- Add `enabled` column so that users can be suspended

__Note: There are several duplicate usernames in the test environment and possibly in prod too. Duplicates will need to be  manually removed or marked `active=false` before running the migration to ensure the correct account is retained.__