### PR TITLE
feat: create domain event table for main db

### DIFF
--- a/main/migrations/20210208213802-AddDomainEventTable.js
+++ b/main/migrations/20210208213802-AddDomainEventTable.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210208213802-AddDomainEventTable-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20210208213802-AddDomainEventTable-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/main/migrations/sqls/20210208213802-AddDomainEventTable-down.sql
+++ b/main/migrations/sqls/20210208213802-AddDomainEventTable-down.sql
@@ -1,0 +1,4 @@
+/* Replace with your SQL commands */
+DROP INDEX event_status_idx;
+DROP INDEX event_pyld_idx;
+DROP TABLE domain_event;

--- a/main/migrations/sqls/20210208213802-AddDomainEventTable-up.sql
+++ b/main/migrations/sqls/20210208213802-AddDomainEventTable-up.sql
@@ -1,11 +1,24 @@
 /* Replace with your SQL commands */
 CREATE TABLE domain_event
 (
-    id uuid NOT NULL PRIMARY KEY,
+    id uuid NOT NULL,
     payload jsonb NOT NULL,
     status varchar NOT NULL,
     created_at timestamptz NOT NULL,
-    updated_at timestamptz NOT NULL
-);
+    updated_at timestamptz NOT NULL,
+    CONSTRAINT domain_event_pkey PRIMARY KEY (id, status, created_at)
+) PARTITION BY LIST (status);
+
 CREATE INDEX event_status_idx ON domain_event (status);
 CREATE INDEX event_pyld_idx ON domain_event USING GIN (payload jsonb_path_ops);
+
+CREATE TABLE domain_event_raised PARTITION OF domain_event FOR VALUES IN ('raised');
+CREATE TABLE domain_event_received PARTITION OF domain_event FOR VALUES IN ('received');
+CREATE TABLE domain_event_sent PARTITION OF domain_event FOR VALUES IN ('sent') PARTITION BY RANGE (created_at);
+CREATE TABLE domain_event_handled PARTITION OF domain_event FOR VALUES IN ('handled') PARTITION BY RANGE (created_at);
+CREATE TABLE domain_event_sent_2021 partition of domain_event_sent FOR VALUES FROM ('2021-01-01') TO ('2022-01-01');
+CREATE TABLE domain_event_sent_2022 partition of domain_event_sent FOR VALUES FROM ('2022-01-01') TO ('2023-01-01');
+CREATE TABLE domain_event_sent_2023 partition of domain_event_sent FOR VALUES FROM ('2023-01-01') TO ('2024-01-01');
+CREATE TABLE domain_event_handled_2021 partition of domain_event_handled FOR VALUES FROM ('2021-01-01') TO ('2022-01-01');
+CREATE TABLE domain_event_handled_2022 partition of domain_event_handled FOR VALUES FROM ('2022-01-01') TO ('2023-01-01');
+CREATE TABLE domain_event_handled_2023 partition of domain_event_handled FOR VALUES FROM ('2023-01-01') TO ('2024-01-01');

--- a/main/migrations/sqls/20210208213802-AddDomainEventTable-up.sql
+++ b/main/migrations/sqls/20210208213802-AddDomainEventTable-up.sql
@@ -1,0 +1,11 @@
+/* Replace with your SQL commands */
+CREATE TABLE domain_event
+(
+    id uuid NOT NULL PRIMARY KEY,
+    payload jsonb NOT NULL,
+    status varchar NOT NULL,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL
+);
+CREATE INDEX event_status_idx ON domain_event (status);
+CREATE INDEX event_pyld_idx ON domain_event USING GIN (payload jsonb_path_ops);


### PR DESCRIPTION
Adding a domain event table to support storing events originating from admin panel. This is required to ensure events don't get dropped due to various reasons and are stored in db before publishing it to the queue.