### PR TITLE
chore: add time_created index to trees table

### DIFF
--- a/main/migrations/20220321204803-AddTimeCreatedIndexToTreesTable.js
+++ b/main/migrations/20220321204803-AddTimeCreatedIndexToTreesTable.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var async = require('async');
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db, callback) {
+  async.series(
+    [
+      db.addIndex.bind(db, 'trees', 'trees_time_created_idx', ['time_created']),
+    ],
+    callback
+  );
+};
+
+exports.down = function(db, callback) {
+  async.series(
+    [
+      db.removeIndex.bind(db, 'trees', 'trees_time_created_idx'),
+    ],
+    callback
+  );
+};
+
+exports._meta = {
+  "version": 1
+};


### PR DESCRIPTION
This should address some of the performance issues we're seeing with the Captures and Verity tools in production.