### PR TITLE
feat: replace time_created index with multicolumn index

### DIFF
--- a/main/migrations/20220327195148-UpdateTreesTableIndexes.js
+++ b/main/migrations/20220327195148-UpdateTreesTableIndexes.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var async = require('async');
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db, callback) {
+  async.series(
+    [
+      // Remove old index first
+      db.removeIndex.bind(db, 'trees', 'trees_time_created_idx'),
+      db.addIndex.bind(db, 'trees', 'trees_verify_query_idx', ['planter_id', 'approved', 'time_created']),
+    ],
+    callback
+  );
+};
+
+exports.down = function(db, callback) {
+  async.series(
+    [
+      db.removeIndex.bind(db, 'trees', 'trees_verify_query_idx'),
+      // Reinstate old index
+      db.addIndex.bind(db, 'trees', 'trees_time_created_idx', ['time_created']),
+    ],
+    callback
+  );
+};
+
+exports._meta = {
+  "version": 1
+};


### PR DESCRIPTION
`trees` queries with more than a handful of `planter_id` values were exclusively using the `time_created` index, which is extremely slow on its own in this case.
This multicolumn index combines the two columns (and `approved`, which is also usually explicitly indexed) to make queries more predictable and performant.