### PR TITLE
fix: create indexes for species and approved count

### DIFF
--- a/main/migrations/20220611154725-AddSpeciesAndVerificationIndexes.js
+++ b/main/migrations/20220611154725-AddSpeciesAndVerificationIndexes.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var async = require('async');
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db, callback) {
+  async.series(
+    [
+      db.addIndex.bind(db, 'trees', 'trees_active_approved_idx', ['active','approved']),
+      db.addIndex.bind(db, 'trees', 'trees_active_species_id_idx', ['active','species_id']),
+    ],
+    callback
+  );
+};
+
+exports.down = function(db, callback) {
+  async.series(
+    [
+      db.removeIndex.bind(db, 'trees', 'trees_active_approved_idx'),
+      db.removeIndex.bind(db, 'trees', 'trees_active_species_id_idx'),
+    ],
+    callback
+  );
+};
+
+exports._meta = {
+  "version": 1
+};


### PR DESCRIPTION
Resolves #104 
## Verification State Count
```
explain select count(*) from public.trees where active = true and approved = true
```
### Before
```
Finalize Aggregate  (cost=72556.83..72556.84 rows=1 width=8)
  ->  Gather  (cost=72556.61..72556.82 rows=2 width=8)
        Workers Planned: 2
        ->  Partial Aggregate  (cost=71556.61..71556.62 rows=1 width=8)
              ->  Parallel Index Scan using trees_approved_idx on trees  (cost=0.42..71123.79 rows=173131 width=0)
                    Index Cond: (approved = true)
                    Filter: (active AND approved)
```
### After
```
Finalize Aggregate  (cost=22205.66..22205.67 rows=1 width=8)
  ->  Gather  (cost=22205.45..22205.66 rows=2 width=8)
        Workers Planned: 2
        ->  Partial Aggregate  (cost=21205.45..21205.46 rows=1 width=8)
              ->  Parallel Index Only Scan using trees_active_approved_idx on trees  (cost=0.42..20772.62 rows=173131 width=0)
                    Index Cond: ((active = true) AND (approved = true))
                    Filter: (active AND approved)
```
## Species Count
```
explain select species_id from public.trees where active=true group by species_id
```
### Before
```
Group  (cost=78137.62..78143.82 rows=26 width=4)
  Group Key: species_id
  ->  Gather Merge  (cost=78137.62..78143.69 rows=52 width=4)
        Workers Planned: 2
        ->  Sort  (cost=77137.60..77137.67 rows=26 width=4)
              Sort Key: species_id
              ->  Partial HashAggregate  (cost=77136.73..77136.99 rows=26 width=4)
                    Group Key: species_id
                    ->  Parallel Seq Scan on trees  (cost=0.00..76446.49 rows=276097 width=4)
                          Filter: active
```
### After
```
Group  (cost=1000.45..28834.79 rows=26 width=4)
  Group Key: species_id
  ->  Gather Merge  (cost=1000.45..28834.66 rows=52 width=4)
        Workers Planned: 2
        ->  Group  (cost=0.42..27828.63 rows=26 width=4)
              Group Key: species_id
              ->  Parallel Index Only Scan using trees_active_species_id_idx on trees  (cost=0.42..27138.39 rows=276097 width=4)
                    Index Cond: (active = true)
                    Filter: active
```