### PR TITLE
feat: add uuid column to tree_species table

### DIFF
--- a/main/migrations/20221101211811-AddUuidToSpecies.js
+++ b/main/migrations/20221101211811-AddUuidToSpecies.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  return db.addColumn('tree_species', 'uuid', { type: 'uuid', defaultValue: new String('uuid_generate_v4()')});
+};
+
+exports.down = function(db) {
+  return db.removeColumn('tree_species', 'uuid');
+};
+
+exports._meta = {
+  "version": 1
+};


### PR DESCRIPTION
`uuid` (auto-generated) in legacy `public.tree_species` table to support migration of species to microservices.